### PR TITLE
#142 Return correct type.

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/fixture/AbstractComponentFixture.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/fixture/AbstractComponentFixture.java
@@ -429,7 +429,7 @@ public abstract class AbstractComponentFixture<S, C extends Component, D extends
    * @throws AssertionError if this fixture's {@code Component} is not an instance of the given type.
    */
   public final @Nonnull
-  <T extends C> C targetCastedTo(@Nonnull Class<T> type) {
+  <T extends C> T targetCastedTo(@Nonnull Class<T> type) {
     assertThat(target).as(format(target)).isInstanceOf(type);
     return type.cast(target);
   }

--- a/assertj-swing/src/test/java/org/assertj/swing/fixture/AbstractComponentFixture_targetCastedTo_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/fixture/AbstractComponentFixture_targetCastedTo_Test.java
@@ -1,0 +1,66 @@
+/*
+ * Created on Feb 18, 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2013 the original author or authors.
+ */
+package org.assertj.swing.fixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.awt.Component;
+
+import javax.annotation.Nonnull;
+import javax.swing.JTable;
+
+import org.assertj.swing.core.Robot;
+import org.assertj.swing.driver.ComponentDriver;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AbstractComponentFixture#targetCastedTo(Class)}.
+ * 
+ * @author Christian Rösch
+ */
+public class AbstractComponentFixture_targetCastedTo_Test {
+
+  @Test
+  public void should_Return_Object_Reference_Passed_Via_Constructor() {
+    Component table = new JTable();
+    ConcreteComponentFixture fixture = new ConcreteComponentFixture(table);
+
+    assertThat(fixture.targetCastedTo(JTable.class)).isSameAs(table);
+  }
+
+  @Test
+  public void should_Return_Object_Of_Type_The_Component_Is_Casted_To() {
+    Component table = new JTable();
+    ConcreteComponentFixture fixture = new ConcreteComponentFixture(table);
+
+    // check that it compiles
+    @SuppressWarnings("unused")
+    JTable castedTarget = fixture.targetCastedTo(JTable.class);
+  }
+
+  private static class ConcreteComponentFixture extends
+      AbstractComponentFixture<ConcreteComponentFixture, Component, ComponentDriver> {
+    public ConcreteComponentFixture(Component component) {
+      super(ConcreteComponentFixture.class, mock(Robot.class), component);
+    }
+
+    @Override
+    protected @Nonnull
+    ComponentDriver createDriver(@Nonnull Robot robot) {
+      return mock(ComponentDriver.class);
+    }
+  }
+}


### PR DESCRIPTION
Previously the cast of the object was performed but the return type
didn't reflect that. So surrounding code that needed the cast would
break.
