### PR TITLE
display current focus owner when focus switch times out

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
@@ -290,7 +290,7 @@ public class BasicRobot implements Robot {
         TimeoutWatch watch = startWatchWithTimeoutOf(settings().timeoutToBeVisible());
         while (!focusMonitor.hasFocus()) {
           if (watch.isTimeOut()) {
-            throw actionFailure(concat("Focus change to ", format(target), " failed"));
+              throw actionFailure(concat("Focus change to ", format(target), " failed", " focus owner: ", format(FocusOwnerFinder.focusOwner())));
           }
           pause();
         }


### PR DESCRIPTION
I've been debugging focus issues with running assertj-swing headless using [cacio](http://openjdk.java.net/projects/caciocavallo/), having this statement makes it easier to determine where focus is stuck at.
