### PR TITLE
Stop checking conditions if the condition should have timed out.

### DIFF
--- a/assertj-swing/src/test/java/org/assertj/swing/timing/NeverSatisfiedCondition.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/timing/NeverSatisfiedCondition.java
@@ -14,18 +14,27 @@
  */
 package org.assertj.swing.timing;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * A {@link Condition} that is never satisfied.
  * 
  * @author Alex Ruiz
  */
 class NeverSatisfiedCondition extends Condition {
+  private AtomicInteger count;
   public NeverSatisfiedCondition() {
     super("Never satisfied");
+    count = new AtomicInteger(0);
   }
 
   @Override
   public boolean test() {
+    count.incrementAndGet();
     return false;
+  }
+
+  public int getCount() {
+    return count.get();
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/timing/Pause_pauseWithConditionAndTimeoutInMilliseconds_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/timing/Pause_pauseWithConditionAndTimeoutInMilliseconds_Test.java
@@ -15,6 +15,7 @@
 package org.assertj.swing.timing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.swing.test.util.StopWatch.startNewStopWatch;
 
 import org.assertj.swing.exception.WaitTimedOutError;
@@ -30,6 +31,31 @@ public class Pause_pauseWithConditionAndTimeoutInMilliseconds_Test {
   @Test(expected = WaitTimedOutError.class)
   public void should_Timeout_If_Condition_Is_Never_Satisfied() {
     Pause.pause(new NeverSatisfiedCondition(), 1000);
+  }
+
+    @Test
+  public void should_Stop_Condition_if_Timedout() throws InterruptedException {
+    NeverSatisfiedCondition condition = new NeverSatisfiedCondition();
+    try {
+      Pause.pause(condition, 1000);
+      fail("Should have timed out");
+    } catch(WaitTimedOutError e) {
+      // expected
+    }
+
+    long start = System.currentTimeMillis();
+    while(true) {
+      int lastCount = condition.getCount();
+      Thread.sleep(2000);
+      System.out.println(condition.getCount() + " == " + lastCount);
+      if (condition.getCount() == lastCount) {
+        break;
+      }
+
+      if (System.currentTimeMillis() > (start + 20000)) {
+        fail("Condition was still being tested 20 seconds after the condition timed out");
+      }
+    }
   }
 
   @Test(expected = WaitTimedOutError.class, timeout = 1100)


### PR DESCRIPTION
If a condition will never be satisfied the thread will loop forever until the JVM exits or some other error occurs.

This should fix https://github.com/joel-costigliola/assertj-swing/issues/152.

It seemed to not cause any additional test failures however the tests were not all passing before this change.  I was using a remote desktop connection and this has been flakey for me in the past.  I can retry on Monday when I will be nearer my actual computer.