### PR TITLE
add a simpler waitForIdle implementation

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
@@ -80,6 +80,7 @@ import org.assertj.swing.edt.GuiQuery;
 import org.assertj.swing.edt.GuiTask;
 import org.assertj.swing.exception.ActionFailedException;
 import org.assertj.swing.exception.ComponentLookupException;
+import org.assertj.swing.exception.UnexpectedException;
 import org.assertj.swing.exception.WaitTimedOutError;
 import org.assertj.swing.hierarchy.ComponentHierarchy;
 import org.assertj.swing.hierarchy.ExistingHierarchy;
@@ -721,14 +722,18 @@ public class BasicRobot implements Robot {
   @Override
   public void waitForIdle() {
     waitIfNecessary();
-    Collection<EventQueue> queues = windowMonitor.allEventQueues();
-    if (queues.size() == 1) {
-      waitForIdle(checkNotNull(toolkit.getSystemEventQueue()));
-      return;
-    }
-    // FIXME this resurrects dead event queues
-    for (EventQueue queue : queues) {
-      waitForIdle(checkNotNull(queue));
+    if (settings.simpleWaitForIdle()) {
+      simpleWaitForIdle();
+    } else {
+      Collection<EventQueue> queues = windowMonitor.allEventQueues();
+      if (queues.size() == 1) {
+        waitForIdle(checkNotNull(toolkit.getSystemEventQueue()));
+        return;
+      }
+      // FIXME this resurrects dead event queues
+      for (EventQueue queue : queues) {
+        waitForIdle(checkNotNull(queue));
+      }
     }
   }
 
@@ -738,6 +743,17 @@ public class BasicRobot implements Robot {
     if (eventPostingDelay > delayBetweenEvents) {
       pause(eventPostingDelay - delayBetweenEvents);
     }
+  }
+
+  private void simpleWaitForIdle() {
+      if (EventQueue.isDispatchThread()) {
+          throw new IllegalThreadStateException("Cannot call method from the event dispatcher thread");
+      }
+      try {
+          EventQueue.invokeAndWait(EMPTY_RUNNABLE);
+      } catch (Exception e) {
+          throw new UnexpectedException("could not invokeAndWait", e);
+      }
   }
 
   private void waitForIdle(@Nonnull EventQueue eventQueue) {

--- a/assertj-swing/src/main/java/org/assertj/swing/core/Settings.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/Settings.java
@@ -42,6 +42,7 @@ public class Settings {
   private int dropDelay;
   private int eventPostingDelay;
   private int idleTimeout;
+  private boolean simpleWaitForIdle;
 
   private java.awt.Robot robot;
 
@@ -255,5 +256,19 @@ public class Settings {
 
   private int valueToUpdate(int value, int min, int max) {
     return max(min, min(max, value));
+  }
+
+  /**
+   * @return the simple waitForIdle implementation is on or off
+   */
+  public boolean simpleWaitForIdle() {
+    return simpleWaitForIdle;
+  }
+
+  /**
+   * turns on or off the simple waitForIdle implementation
+   */
+  public void simpleWaitForIdle(boolean simpleWaitForIdle) {
+    this.simpleWaitForIdle = simpleWaitForIdle;
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/core/CustomEventQueue_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/CustomEventQueue_Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 Entero Corporation. All Rights Reserved.
+ * www.entero.com
+ */
+package org.assertj.swing.core;
+
+import org.assertj.swing.test.recorder.KeyRecorder;
+import org.assertj.swing.timing.Condition;
+import org.junit.After;
+import org.junit.Test;
+
+import java.awt.*;
+import java.util.concurrent.Executors;
+
+import static java.awt.event.KeyEvent.*;
+import static org.assertj.swing.timing.Pause.pause;
+import static org.assertj.swing.timing.Timeout.timeout;
+import static org.fest.util.Arrays.array;
+
+/**
+ * Tests for issue with slow waitForIdle with a custom event queue
+ */
+public class CustomEventQueue_Test extends BasicRobot_TestCase {
+  private CustomEventQueue newEventQueue = new CustomEventQueue();
+
+  @Override
+  void beforeShowingWindow() {
+    robot().settings().simpleWaitForIdle(true);
+    Toolkit.getDefaultToolkit().getSystemEventQueue().push(newEventQueue);
+  }
+
+  @After
+  public void cleanup() {
+    newEventQueue.remove();
+  }
+
+  @Test
+  public void type_keys_before_timeout() {
+    giveFocusToTextField();
+    final KeyRecorder recorder = KeyRecorder.attachTo(window().textField());
+    Executors.newSingleThreadExecutor().execute(new Runnable() {
+      public void run() {
+        robot().pressAndReleaseKeys(VK_A, VK_B, VK_C);
+      }
+    });
+    pause(new Condition("until all keys are typed") {
+      @Override
+      public boolean test() {
+        Integer[] expectedKeys = array(VK_A, VK_B, VK_C);
+        return recorder.keysWerePressed(expectedKeys) && recorder.keysWereReleased(expectedKeys);
+      }
+    }, timeout(1000));
+  }
+
+  private class CustomEventQueue extends EventQueue {
+    protected void dispatchEvent(final AWTEvent event) {
+      super.dispatchEvent(event);
+    }
+
+    public void remove() {
+      pop();
+    }
+  }
+}


### PR DESCRIPTION
I decided it was best to leave the old implementation as well since it handles multiple queues (i.e. applets), I'm not sure if anyone is using that however.