### PR TITLE
TC to show waitForIdle issue

### DIFF
--- a/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_waitForIdle_Test
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_waitForIdle_Test
@@ -24,7 +24,6 @@ public class BasicRobot_waitForIdle_Test extends BasicRobot_TestCase {
       @Override
       protected void executeInEDT() {
         BasicRobot_waitForIdle_Test.this.window().textField().setEnabled(false);
-        System.out.println("Disabled TB");
         new Thread(() -> {
           try {
             Thread.sleep(2000); // Simulate fetching something from the DB

--- a/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_waitForIdle_Test
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_waitForIdle_Test
@@ -1,0 +1,40 @@
+package org.assertj.swing.core;
+
+import static org.assertj.swing.edt.GuiActionRunner.execute;
+
+import java.awt.EventQueue;
+
+import org.assertj.swing.annotation.RunsInEDT;
+import org.assertj.swing.edt.GuiTask;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BasicRobot_waitForIdle_Test extends BasicRobot_TestCase {
+  @Test
+  public final void test() {
+    this.robot().focusAndWaitForFocusGain(this.window().textField());
+    this.robot().enterText("Test");
+    Assert.assertEquals("Test", this.window().textField().getText());
+  }
+
+  @RunsInEDT
+  @Override
+  void beforeShowingWindow() {
+    execute(new GuiTask() {
+      @Override
+      protected void executeInEDT() {
+        BasicRobot_waitForIdle_Test.this.window().textField().setEnabled(false);
+        System.out.println("Disabled TB");
+        new Thread(() -> {
+          try {
+            Thread.sleep(2000); // Simulate fetching something from the DB
+            EventQueue.invokeAndWait(() -> BasicRobot_waitForIdle_Test.this.window().textField()
+                .setEnabled(true));
+          } catch (final Exception e) {
+            e.printStackTrace();
+          }
+        }).start();
+      }
+    });
+  }
+}


### PR DESCRIPTION
Hi @croesch ,

This TC shows a problem in the current way that asserj-swing is waiting for idle. Do you think it is possible to fix it in some way? It is not really possible to find out, whether a thread is "idle". However it would be beneficial to be able to dispatch events in non-EDT threads.

Cheers