### PR TITLE
Timeout for BasicComponentFinder

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/core/Settings.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/Settings.java
@@ -35,6 +35,7 @@ public class Settings {
   private int timeoutToBeVisible;
   private int timeoutToFindPopup;
   private int timeoutToFindSubMenu;
+  private int timeoutToFind;
   private int delayBetweenEvents;
   private int dragDelay;
   private int dropDelay;
@@ -48,6 +49,7 @@ public class Settings {
     timeoutToBeVisible(DEFAULT_DELAY);
     timeoutToFindPopup(DEFAULT_DELAY);
     timeoutToFindSubMenu(100);
+    timeoutToFind(3000);
     delayBetweenEvents(60);
     dragDelay(0);
     dropDelay(0);
@@ -116,6 +118,23 @@ public class Settings {
    */
   public void timeoutToBeVisible(int ms) {
     timeoutToBeVisible = valueToUpdate(ms, 0, 60000);
+  }
+
+  /**
+   * @return the number of milliseconds to wait before failing to find a component. The default
+   *         value is 30000 milliseconds.
+   */
+  public int timeoutToFind() {
+    return timeoutToFind;
+  }
+
+  /**
+   * Updates the number of milliseconds to wait before failing to find a component. The default value is
+   *         3000 milliseconds.
+   * @param ms the time in milliseconds. It should be between 0 and 60000.
+   */
+  public void timeoutToFind(int ms) {
+    timeoutToFind = valueToUpdate(ms, 0, 60000);
   }
 
   /**

--- a/assertj-swing/src/test/java/org/assertj/swing/core/BasicComponentFinder_findWithTimeout_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/BasicComponentFinder_findWithTimeout_Test.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.swing.core;
+
+import org.assertj.swing.timing.Pause;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.swing.*;
+import java.awt.*;
+import java.util.Collection;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link BasicComponentFinder#findAll(ComponentMatcher)}.
+ *
+ * @author Alex Ruiz
+ * @author Yvonne Wang
+ */
+public class BasicComponentFinder_findWithTimeout_Test extends BasicComponentFinder_TestCase {
+    @Test
+    public void should_wait_for_given_timeout() {
+
+        Executors.newSingleThreadExecutor().execute(() -> {
+            Pause.pause(250);
+            EventQueue.invokeLater(() -> window.button.setText("A Changed Button"));
+        });
+
+        Component found = finder.find(new GenericTypeMatcher<JButton>(JButton.class) {
+            @Override
+            protected boolean isMatching(@Nonnull JButton component) {
+                return "A Changed Button".equals(component.getText());
+            }
+        });
+
+
+        assertThat(found).isEqualTo(window.button);
+    }
+}

--- a/assertj-swing/src/test/java/org/assertj/swing/core/BasicComponentFinder_findWithTimeout_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/BasicComponentFinder_findWithTimeout_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.swing.core;
 
+import org.assertj.swing.hierarchy.ExistingHierarchy;
 import org.assertj.swing.timing.Pause;
 import org.junit.Test;
 
@@ -32,7 +33,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class BasicComponentFinder_findWithTimeout_Test extends BasicComponentFinder_TestCase {
     @Test
-    public void should_wait_for_given_timeout() {
+    public void should_try_to_find_until_timeout_passed() {
+
+        Settings settings = new Settings();
+        finder = new BasicComponentFinder(new ExistingHierarchy(), settings);
+
 
         Executors.newSingleThreadExecutor().execute(() -> {
             Pause.pause(250);
@@ -49,4 +54,6 @@ public class BasicComponentFinder_findWithTimeout_Test extends BasicComponentFin
 
         assertThat(found).isEqualTo(window.button);
     }
+
+
 }


### PR DESCRIPTION
Configurable timeout for BasicComponentFinder so that find doesn't fail immediately if match is not found. Resolves #175 
