### PR TITLE
Component size check and timeout for BasicRobot.click

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
@@ -450,6 +450,9 @@ public class BasicRobot implements Robot {
   @RunsInEDT
   @Override
   public void click(@Nonnull Component c, @Nonnull Point where, @Nonnull MouseButton button, int times) {
+    if (!waitForComponentToBeReady(c, settings.timeoutToBeVisible())) {
+      throw actionFailure(concat("Could not obtain position of component ", format(c)));
+    }
     doClick(c, where, button, times);
   }
 

--- a/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/BasicRobot.java
@@ -877,7 +877,7 @@ public class BasicRobot implements Robot {
     if (w == null) {
       throw actionFailure(concat("Component ", format(c), " does not have a Window ancestor"));
     }
-    return c.isShowing() && windowMonitor.isWindowReady(w);
+    return c.isShowing() && c.getWidth() > 0 && c.getHeight() > 0 && windowMonitor.isWindowReady(w);
   }
 
   @RunsInEDT

--- a/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_TestCase.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_TestCase.java
@@ -93,7 +93,7 @@ public abstract class BasicRobot_TestCase extends EDTSafeTestCase {
     private MyWindow(@Nonnull Class<?> testClass) {
       super(testClass);
       addComponents(textField);
-      setMinimumSize(new Dimension(100, 50));
+      setMinimumSize(new Dimension(100, 100));
     }
 
     @Nonnull

--- a/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_clickComponentTimeout_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_clickComponentTimeout_Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.swing.core;
+
+import org.assertj.swing.test.recorder.ClickRecorder;
+import org.assertj.swing.timing.Pause;
+import org.junit.Test;
+
+import javax.swing.*;
+import java.awt.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.Executors;
+
+import static org.assertj.swing.core.MouseButton.LEFT_BUTTON;
+
+/**
+ * Tests for {@link BasicRobot#click(java.awt.Component)}.
+ * 
+ * @author Yvonne Wang
+ * @author Alex Ruiz
+ */
+public class BasicRobot_clickComponentTimeout_Test extends BasicRobot_ClickTestCase {
+  @Test
+  public void should_Click_Component() throws InvocationTargetException, InterruptedException {
+    EventQueue.invokeAndWait(() -> window().textField().setVisible(false));
+
+    Executors.newSingleThreadExecutor().execute(() -> {
+      Pause.pause(250);
+      EventQueue.invokeLater(() -> window().textField().setVisible(true));
+    });
+
+    ClickRecorder recorder = clickRecorder.attachDirectlyTo(window().textField());
+    robot().click(window().textField());
+    recorder.clicked(LEFT_BUTTON).timesClicked(1);
+
+
+  }
+}

--- a/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_clickComponentTimeout_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/core/BasicRobot_clickComponentTimeout_Test.java
@@ -12,16 +12,21 @@
  */
 package org.assertj.swing.core;
 
+import org.assertj.swing.exception.ActionFailedException;
+import org.assertj.swing.exception.WaitTimedOutError;
 import org.assertj.swing.test.recorder.ClickRecorder;
-import org.assertj.swing.timing.Pause;
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import javax.swing.*;
 import java.awt.*;
+import java.awt.event.AWTEventListener;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Executors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.swing.core.MouseButton.LEFT_BUTTON;
+import static org.assertj.swing.timing.Pause.pause;
+import static org.mockito.Matchers.anyObject;
 
 /**
  * Tests for {@link BasicRobot#click(java.awt.Component)}.
@@ -31,18 +36,50 @@ import static org.assertj.swing.core.MouseButton.LEFT_BUTTON;
  */
 public class BasicRobot_clickComponentTimeout_Test extends BasicRobot_ClickTestCase {
   @Test
-  public void should_Click_Component() throws InvocationTargetException, InterruptedException {
+  public void should_click_component_after_it_is_visible() throws InvocationTargetException, InterruptedException {
     EventQueue.invokeAndWait(() -> window().textField().setVisible(false));
 
     Executors.newSingleThreadExecutor().execute(() -> {
-      Pause.pause(250);
+      pause(250);
       EventQueue.invokeLater(() -> window().textField().setVisible(true));
     });
 
     ClickRecorder recorder = clickRecorder.attachDirectlyTo(window().textField());
     robot().click(window().textField());
     recorder.clicked(LEFT_BUTTON).timesClicked(1);
+  }
 
+  @Test
+  public void should_click_component_after_it_resizes_to_visible() throws InvocationTargetException, InterruptedException {
+    EventQueue.invokeAndWait(() -> window().textField().setSize(-10, -10));
 
+    Executors.newSingleThreadExecutor().execute(() -> {
+      pause(300);
+      EventQueue.invokeLater(() -> window().textField().setSize(10, 10));
+    });
+
+    ClickRecorder recorder = clickRecorder.attachDirectlyTo(window().textField());
+    robot().click(window().textField());
+    recorder.clicked(LEFT_BUTTON).timesClicked(1);
+  }
+
+  @Test
+  public void should_not_click_if_component_size_is_negative() throws InvocationTargetException, InterruptedException, ActionFailedException {
+    robot().settings().timeoutToBeVisible(300);
+    EventQueue.invokeAndWait(() -> window().textField().setSize(-10, -10));
+
+    AWTEventListener listener = Mockito.mock(AWTEventListener.class);
+    Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.MOUSE_EVENT_MASK);
+    try {
+      robot().click(window().textField());
+    } catch (ActionFailedException e) {}
+    Mockito.verify(listener, Mockito.never()).eventDispatched(anyObject());
+  }
+
+  @Test(expected = ActionFailedException.class)
+  public void should_throw_exception_after_timeout() throws InvocationTargetException, InterruptedException {
+    robot().settings().timeoutToBeVisible(300);
+    EventQueue.invokeAndWait(() -> window().textField().setSize(-10, -10));
+      robot().click(window().textField());
   }
 }


### PR DESCRIPTION
Checking that component's size is sensible and wait at least until timeout passes before failing. Resolves #177 
