### PR TITLE
IntrospectionComponentFormatter should show real class name for anonymous classes

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/format/IntrospectionComponentFormatter.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/format/IntrospectionComponentFormatter.java
@@ -94,7 +94,7 @@ public final class IntrospectionComponentFormatter extends ComponentFormatterTem
   @Override
   protected @Nonnull String doFormat(@Nonnull Component c) {
     StringBuilder b = new StringBuilder();
-    b.append(c.getClass().getName()).append("[");
+    b.append(getRealClassName(c.getClass())).append("[");
     int max = propertyNames.size() - 1;
     for (int i = 0; i <= max; i++) {
       appendProperty(b, checkNotNull(propertyNames.get(i)), c);
@@ -143,5 +143,11 @@ public final class IntrospectionComponentFormatter extends ComponentFormatterTem
   public String toString() {
     return String.format("%s[propertyNames=%s", getClass().getName(),
         new StandardRepresentation().toStringOf(propertyNames));
+  }
+
+  protected String getRealClassName(Class type) {
+    if(type.isAnonymousClass())
+      return getRealClassName(type.getSuperclass());
+    return type.getName();
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/format/IntrospectionComponentFormatter_format_anonymous_class_names_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/format/IntrospectionComponentFormatter_format_anonymous_class_names_Test.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.swing.format;
+
+import org.assertj.swing.annotation.RunsInEDT;
+import org.assertj.swing.test.core.EDTSafeTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.swing.test.builder.JComboBoxes.comboBox;
+
+/**
+ * Tests for {@link IntrospectionComponentFormatter#format(java.awt.Component)}.
+ * 
+ * @author Timo Mikkilä
+ */
+public class IntrospectionComponentFormatter_format_anonymous_class_names_Test {
+
+  JButton button;
+  private IntrospectionComponentFormatter formatter;
+
+  @Before
+  public void setUp() {
+    formatter = new IntrospectionComponentFormatter(JButton.class);
+    button = new JButton() {
+
+    };
+  }
+
+  @Test
+  public void should_Show_Real_Name_Of_Anynomous_Class() {
+    assertThat(formatter.format(button)).startsWith("javax.swing.JButton");
+  }
+
+}

--- a/assertj-swing/src/test/java/org/assertj/swing/format/IntrospectionComponentFormatter_format_anonymous_class_names_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/format/IntrospectionComponentFormatter_format_anonymous_class_names_Test.java
@@ -12,15 +12,12 @@
  */
 package org.assertj.swing.format;
 
-import org.assertj.swing.annotation.RunsInEDT;
-import org.assertj.swing.test.core.EDTSafeTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.swing.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.swing.test.builder.JComboBoxes.comboBox;
 
 /**
  * Tests for {@link IntrospectionComponentFormatter#format(java.awt.Component)}.


### PR DESCRIPTION
Currently IntrospectionComponentFormatter shows anonymous classes with following format: base.component.package.BaseComponent$1. This does not give enough feedback of what the component really is. In my solution the real class name is digged from the anonymous class.