### PR TITLE
RobotEventGenerator uses AWT.translate() outside the EDT

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/core/RobotEventGenerator.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/RobotEventGenerator.java
@@ -15,6 +15,7 @@ package org.assertj.swing.core;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.swing.awt.AWT.isPointInScreenBoundaries;
 import static org.assertj.swing.awt.AWT.translate;
+import static org.assertj.swing.edt.GuiActionRunner.execute;
 import static org.assertj.swing.exception.ActionFailedException.actionFailure;
 import static org.assertj.swing.exception.UnexpectedException.unexpected;
 import static org.assertj.swing.timing.Pause.pause;
@@ -28,6 +29,7 @@ import java.awt.Robot;
 
 import javax.annotation.Nonnull;
 
+import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.util.RobotFactory;
 
 /**
@@ -67,9 +69,10 @@ class RobotEventGenerator implements InputEventGenerator {
     return robot;
   }
 
+  @RunsInEDT
   @Override
   public void pressMouse(@Nonnull Component c, @Nonnull Point where, int buttons) {
-    Point p = checkNotNull(translate(c, where.x, where.y));
+    Point p = checkNotNull(execute(() -> translate(c, where.x, where.y)));
     if (!isPointInScreenBoundaries(p)) {
       throw actionFailure("The component to click is out of the boundaries of the screen");
     }
@@ -97,9 +100,10 @@ class RobotEventGenerator implements InputEventGenerator {
     robot.mouseWheel(amount);
   }
 
+  @RunsInEDT
   @Override
   public void moveMouse(@Nonnull Component c, int x, int y) {
-    Point p = checkNotNull(translate(c, x, y));
+    Point p = checkNotNull(execute(() -> translate(c, x, y)));
     moveMouse(p.x, p.y);
   }
 


### PR DESCRIPTION
RobotEventGenerator uses AWT.translate() outside the EDT, whilst AWT.translate() documents that it must be called on the EDT.
Added @RunInEDT annotation to document that Swing components are accessed on the EDT.

In my setup this issue resulted in a deadlock. _main_ thread obtaining AWT TreeLock and then Sun's AWT lock, whilst some other code on the _EDT_ first obtaining the Sun AWT lock and then the AWT TreeLock.