### PR TITLE
improved fluency for JInternalFrame testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,4 +11,4 @@ To make sure we and others understand you, please file tickets in English. No mo
 Code
 ----
 
-We appreciate your effort and to make sure that your pull request is easy to review, we ask you to make note of the **[assertj-core guidelines](joel-costigliola/assertj-core/CONTRIBUTING.md)**.
+We appreciate your effort and to make sure that your pull request is easy to review, we ask you to make note of the **[assertj-core guidelines](https://github.com/joel-costigliola/assertj-core/blob/master/CONTRIBUTING.md)**.

--- a/assertj-swing/src/main/java/org/assertj/swing/fixture/AbstractContainerFixture.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/fixture/AbstractContainerFixture.java
@@ -27,6 +27,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
+import javax.swing.JInternalFrame;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JMenuItem;
@@ -269,6 +270,24 @@ public abstract class AbstractContainerFixture<S, C extends Container, D extends
     pause(condition, timeout);
     JFileChooser fileChooser = (JFileChooser) condition.found();
     return new JFileChooserFixture(robot(), checkNotNull(fileChooser));
+  }
+
+  @RunsInEDT
+  @Override
+  public @Nonnull JInternalFrameFixture internalFrame() {
+    return new JInternalFrameFixture(robot(), findByType(JInternalFrame.class));
+  }
+
+  @RunsInEDT
+  @Override
+  public @Nonnull JInternalFrameFixture internalFrame(@Nonnull GenericTypeMatcher<? extends JInternalFrame> matcher) {
+    return new JInternalFrameFixture(robot(), find(matcher));
+  }
+
+  @RunsInEDT
+  @Override
+  public @Nonnull JInternalFrameFixture internalFrame(@Nullable String name) {
+    return new JInternalFrameFixture(robot(), findByName(name, JInternalFrame.class));
   }
 
   @RunsInEDT

--- a/assertj-swing/src/main/java/org/assertj/swing/fixture/ComponentContainerFixture.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/fixture/ComponentContainerFixture.java
@@ -21,6 +21,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
+import javax.swing.JInternalFrame;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JMenuItem;
@@ -313,6 +314,45 @@ public interface ComponentContainerFixture {
   @RunsInEDT
   @Nonnull
   JFileChooserFixture fileChooser(@Nullable String name, @Nonnull Timeout timeout);
+
+  /**
+   * Returns a {@link JInternalFrame} found in this fixture's {@code Container}.
+   *
+   * @return a fixture that manages the {@code JInternalFrame} found.
+   * @throws org.assertj.swing.exception.ComponentLookupException if a {@code JInternalFrame} could not be found.
+   * @throws org.assertj.swing.exception.ComponentLookupException if more than one {@code JInternalFrame} is found.
+   */
+  @RunsInEDT
+  @Nonnull
+  JInternalFrameFixture internalFrame();
+
+  /**
+   * Finds a {@link JInternalFrame} in this fixture's {@code Container}, that matches the specified search criteria.
+   *
+   * @param matcher contains the search criteria for finding a {@code JInternalFrame}.
+   * @return a fixture that manages the {@code JInternalFrame} found.
+   * @throws org.assertj.swing.exception.ComponentLookupException if a {@code JInternalFrame} that matches the given
+   *           search criteria could not be found.
+   * @throws org.assertj.swing.exception.ComponentLookupException if more than one {@code JInternalFrame} that matches
+   *           the given search criteria is found.
+   */
+  @RunsInEDT
+  @Nonnull
+  JInternalFrameFixture internalFrame(@Nonnull GenericTypeMatcher<? extends JInternalFrame> matcher);
+
+  /**
+   * Finds a {@link JInternalFrame} in this fixture's {@code Container} whose name matches the specified one.
+   *
+   * @param name the name to match.
+   * @return a fixture that manages the {@code JInternalFrame} found.
+   * @throws org.assertj.swing.exception.ComponentLookupException if a {@code JInternalFrame} having a matching name
+   *           could not be found.
+   * @throws org.assertj.swing.exception.ComponentLookupException if more than one {@code JInternalFrame} having a
+   *           matching name is found.
+   */
+  @RunsInEDT
+  @Nonnull
+  JInternalFrameFixture internalFrame(@Nullable String name);
 
   /**
    * Returns a {@code JLabel} found in this fixture's {@code Container}.

--- a/assertj-swing/src/main/java/org/assertj/swing/fixture/JInternalFrameFixture.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/fixture/JInternalFrameFixture.java
@@ -14,13 +14,17 @@ package org.assertj.swing.fixture;
 
 import java.awt.Dimension;
 import java.awt.Point;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.JInternalFrame;
 
 import org.assertj.swing.core.Robot;
+import org.assertj.swing.core.Settings;
 import org.assertj.swing.driver.JInternalFrameDriver;
+import org.assertj.swing.exception.ActionFailedException;
+import org.assertj.swing.exception.ComponentLookupException;
 
 /**
  * Supports functional testing of {@code JInternalFrame}s
@@ -28,8 +32,8 @@ import org.assertj.swing.driver.JInternalFrameDriver;
  * @author Alex Ruiz
  */
 public class JInternalFrameFixture extends
-    AbstractJPopupMenuInvokerFixture<JInternalFrameFixture, JInternalFrame, JInternalFrameDriver> implements
-    FrameLikeFixture<JInternalFrameFixture> {
+    AbstractContainerFixture<JInternalFrameFixture, JInternalFrame, JInternalFrameDriver> implements
+    FrameLikeFixture<JInternalFrameFixture>, JComponentFixture<JInternalFrameFixture>, JPopupMenuInvokerFixture {
   /**
    * Creates a new {@link JInternalFrameFixture}.
    * 
@@ -58,6 +62,45 @@ public class JInternalFrameFixture extends
   @Override
   protected @Nonnull JInternalFrameDriver createDriver(@Nonnull Robot robot) {
     return new JInternalFrameDriver(robot);
+  }
+
+  /**
+   * Asserts that the toolTip in this fixture's {@code JInternalFrame} matches the given value.
+   *
+   * @param expected the given value. It can be a regular expression.
+   * @return this fixture.
+   * @throws AssertionError if the toolTip in this fixture's {@code JInternalFrame} does not match the given value.
+   */
+  @Override
+  public @Nonnull JInternalFrameFixture requireToolTip(@Nullable String expected) {
+    driver().requireToolTip(target(), expected);
+    return this;
+  }
+
+  /**
+   * Asserts that the toolTip in this fixture's {@code JInternalFrame} matches the given regular expression pattern.
+   *
+   * @param pattern the regular expression pattern to match.
+   * @return this fixture.
+   * @throws NullPointerException if the given regular expression pattern is {@code null}.
+   * @throws AssertionError if the toolTip in this fixture's {@code JInternalFrame} does not match the given regular expression.
+   */
+  @Override
+  public @Nonnull JInternalFrameFixture requireToolTip(@Nonnull Pattern pattern) {
+    driver().requireToolTip(target(), pattern);
+    return this;
+  }
+
+  /**
+   * Returns the client property stored in this fixture's {@code JInternalFrame}, under the given key.
+   *
+   * @param key the key to use to retrieve the client property.
+   * @return the value of the client property stored under the given key, or {@code null} if the property was not found.
+   * @throws NullPointerException if the given key is {@code null}.
+   */
+  @Override
+  public @Nullable Object clientProperty(@Nonnull Object key) {
+    return driver().clientProperty(target(), key);
   }
 
   /**
@@ -201,5 +244,34 @@ public class JInternalFrameFixture extends
   public @Nonnull JInternalFrameFixture moveTo(@Nonnull Point p) {
     driver().move(target(), p);
     return this;
+  }
+
+  /**
+   * Shows a pop-up menu using this fixture's {@code JInternalFrame} as the invoker of the pop-up menu.
+   *
+   * @return a fixture that manages the displayed pop-up menu.
+   * @throws IllegalStateException if {@link Settings#clickOnDisabledComponentsAllowed()} is <code>false</code> and this
+   *           fixture's {@code JInternalFrame} is disabled.
+   * @throws IllegalStateException if this fixture's {@code JInternalFrame} is not showing on the screen.
+   * @throws ComponentLookupException if a pop-up menu cannot be found.
+   */
+  @Override
+  public @Nonnull JPopupMenuFixture showPopupMenu() {
+    return new JPopupMenuFixture(robot(), driver().invokePopupMenu(target()));
+  }
+
+  /**
+   * Shows a pop-up menu at the given point using this fixture's {@code JInternalFrame} as the invoker of the pop-up menu.
+   *
+   * @param p the given point where to show the pop-up menu.
+   * @return a fixture that manages the displayed pop-up menu.
+   * @throws IllegalStateException if {@link Settings#clickOnDisabledComponentsAllowed()} is <code>false</code> and this
+   *           fixture's {@code JInternalFrame} is disabled.
+   * @throws IllegalStateException if this fixture's {@code JInternalFrame} is not showing on the screen.
+   * @throws ComponentLookupException if a pop-up menu cannot be found.
+   */
+  @Override
+  public @Nonnull JPopupMenuFixture showPopupMenuAt(@Nonnull Point p) {
+    return new JPopupMenuFixture(robot(), driver().invokePopupMenu(target(), p));
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/fixture/AbstractContainerFixture_internalFrame_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/fixture/AbstractContainerFixture_internalFrame_Test.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.swing.fixture;
+
+import org.assertj.swing.core.GenericTypeMatcher;
+import org.assertj.swing.exception.ComponentLookupException;
+import org.assertj.swing.test.ExpectedException;
+import org.assertj.swing.test.core.RobotBasedTestCase;
+import org.assertj.swing.test.swing.TestWindow;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import javax.swing.JInternalFrame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.swing.edt.GuiActionRunner.execute;
+import static org.assertj.swing.test.ExpectedException.none;
+import static org.assertj.swing.test.core.NeverMatchingComponentMatcher.neverMatches;
+
+/**
+ * Tests lookups of {@code JInternalFrame}s in {@link AbstractContainerFixture}.
+ * 
+ * @author Abraham Grief
+ */
+public class AbstractContainerFixture_internalFrame_Test extends RobotBasedTestCase {
+  @Rule
+  public ExpectedException thrown = none();
+
+  private ContainerFixture fixture;
+  private MyWindow window;
+
+  @Override
+  protected void onSetUp() {
+    window = MyWindow.createNew(getClass());
+    fixture = new ContainerFixture(robot, window);
+  }
+
+  @Test
+  public void should_Find_Visible_JInternalFrame_By_Name() {
+    robot.showWindow(window);
+    JInternalFrameFixture internalFrame = fixture.internalFrame("testInternalFrame");
+    assertThat(internalFrame.target()).isSameAs(window.internalFrame);
+  }
+
+  @Test
+  public void should_Fail_If_Visible_JInternalFrame_Not_Found_By_Name() {
+    thrown.expect(ComponentLookupException.class);
+    thrown.expectMessageToContain("Unable to find component using matcher",
+        "name='testInternalFrame', type=javax.swing.JInternalFrame, requireShowing=true");
+    fixture.internalFrame("testInternalFrame");
+  }
+
+  @Test
+  public void should_Find_Visible_JInternalFrame_By_Type() {
+    robot.showWindow(window);
+    JInternalFrameFixture internalFrame = fixture.internalFrame();
+    assertThat(internalFrame.target()).isSameAs(window.internalFrame);
+  }
+
+  @Test
+  public void should_Fail_If_Visible_JInternalFrame_Not_Found_By_Type() {
+    thrown.expect(ComponentLookupException.class);
+    thrown.expectMessageToContain("Unable to find component using matcher",
+        "type=javax.swing.JInternalFrame, requireShowing=true");
+    fixture.internalFrame();
+  }
+
+  @Test
+  public void should_Find_Visible_JInternalFrame_By_Matcher() {
+    robot.showWindow(window);
+    JInternalFrameFixture internalFrame =
+      fixture.internalFrame(new GenericTypeMatcher<JInternalFrame>(JInternalFrame.class, true) {
+        @Override
+        protected boolean isMatching(@Nonnull JInternalFrame j) {
+          return "Test Internal Frame Title".equals(j.getTitle()) && requireShowingMatches(j);
+        }
+      });
+    assertThat(internalFrame.target()).isSameAs(window.internalFrame);
+  }
+
+  @Test
+  public void should_Fail_If_Visible_JInternalFrame_Not_Found_By_Matcher() {
+    thrown.expect(ComponentLookupException.class, "Unable to find component using matcher");
+    fixture.internalFrame(neverMatches(JInternalFrame.class));
+  }
+
+  private static class MyWindow extends TestWindow {
+    final JInternalFrame internalFrame = new JInternalFrame("Test Internal Frame Title");
+
+    static MyWindow createNew(final Class<?> testClass) {
+      return execute(() -> new MyWindow(testClass));
+    }
+
+    private MyWindow(Class<?> testClass) {
+      super(testClass);
+      internalFrame.setName("testInternalFrame");
+      addComponents(internalFrame);
+      internalFrame.show();
+    }
+  }
+}

--- a/assertj-swing/src/test/java/org/assertj/swing/fixture/JInternalFrameFixture_withMocks_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/fixture/JInternalFrameFixture_withMocks_Test.java
@@ -15,11 +15,14 @@ package org.assertj.swing.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.awt.Dimension;
 import java.awt.Point;
+import java.util.regex.Pattern;
 
 import javax.swing.JInternalFrame;
+import javax.swing.JPopupMenu;
 
 import org.assertj.swing.core.Robot;
 import org.assertj.swing.driver.JInternalFrameDriver;
@@ -106,5 +109,51 @@ public class JInternalFrameFixture_withMocks_Test {
     Point p = new Point(6, 8);
     assertThat(fixture.moveTo(p)).isSameAs(fixture);
     verify(fixture.driver()).move(fixture.target(), p);
+  }
+
+  @Test
+  public void should_Call_RequireToolTip_With_Text_In_Driver_And_Return_Self() {
+    assertThat(fixture.requireToolTip("Hello")).isSameAs(fixture);
+    verify(fixture.driver()).requireToolTip(fixture.target(), "Hello");
+  }
+
+  @Test
+  public void should_Call_RequireToolTip_With_Pattern_In_Driver_And_Return_Self() {
+    Pattern pattern = Pattern.compile("Hello");
+    assertThat(fixture.requireToolTip(pattern)).isSameAs(fixture);
+    verify(fixture.driver()).requireToolTip(fixture.target(), pattern);
+  }
+
+  @Test
+  public void should_Return_Client_Property_Using_Driver() {
+    when(fixture.driver().clientProperty(fixture.target(), "name")).thenReturn("Yoda");
+    assertThat(fixture.clientProperty("name")).isEqualTo("Yoda");
+    verify(fixture.driver()).clientProperty(fixture.target(), "name");
+  }
+
+  @Test
+  public void should_Show_JPopupMenu_Using_Driver() {
+    JPopupMenu popupMenu = mock(JPopupMenu.class);
+    when(fixture.driver().invokePopupMenu(fixture.target())).thenReturn(popupMenu);
+    JPopupMenuFixture popupMenuFixture = fixture.showPopupMenu();
+    assertThat(popupMenuFixture.target()).isSameAs(popupMenu);
+    verify(fixture.driver()).invokePopupMenu(fixture.target());
+  }
+
+  @Test
+  public void should_Show_JPopupMenu_At_Location_Using_Driver() {
+    Point p = new Point(6, 8);
+    JPopupMenu popupMenu = mock(JPopupMenu.class);
+    when(fixture.driver().invokePopupMenu(fixture.target(), p)).thenReturn(popupMenu);
+    JPopupMenuFixture popupMenuFixture = fixture.showPopupMenuAt(p);
+    assertThat(popupMenuFixture.target()).isSameAs(popupMenu);
+    verify(fixture.driver()).invokePopupMenu(fixture.target(), p);
+  }
+
+  @Test
+  public void should_Call_ResizeTo_In_Driver_And_Return_Self() {
+    Dimension size = new Dimension(6, 8);
+    assertThat(fixture.resizeTo(size)).isSameAs(fixture);
+    verify(fixture.driver()).resizeTo(fixture.target(), size);
   }
 }


### PR DESCRIPTION
Finding components within JInternalFrames was not very fluent, so I changed JInternalFrameFixture to extend AbstractContainerFixture instead of AbstractJPopupMenuInvokerFixture.  I retained all of the functionality of AbstractJPopupMenuInvokerFixture by copying the relevant methods, just like JPanelFixture does.  I also added methods for finding JInternalFrames to AbstractContainerFixture because that wasn't very fluent either.

The end result is that tests involving internal frames now look something like:

`frame.internalFrame().button("Save").click();`

All added methods have supporting unit tests that were adapted from similar tests elsewhere.
