### PR TITLE
JTabbedPane: Expose ToolTipText and Enabled

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/driver/JTabbedPaneDriver.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/driver/JTabbedPaneDriver.java
@@ -57,6 +57,7 @@ import org.assertj.swing.util.TextMatcher;
  *
  * @author Alex Ruiz
  * @author Yvonne Wang
+ * @author William Bakker
  */
 @InternalApi
 public class JTabbedPaneDriver extends JComponentDriver {
@@ -276,14 +277,93 @@ public class JTabbedPaneDriver extends JComponentDriver {
                                                     .isEqualTo(index.value);
   }
 
+  /**
+   * Asserts that the toolTipText of the tab at the given index matches the given value.
+   *
+   * @param tabbedPane the target {@code JTabbedPane}.
+   * @param toolTipText the expected toolTipText. It can be a regular expression.
+   * @param index the index of the tab.
+   * @throws IndexOutOfBoundsException if the given index is not within the {@code JTabbedPane} bounds.
+   * @throws AssertionError if the toolTipText of the tab at the given index does not match the given one.
+   */
+  @RunsInEDT
+  public void requireTabToolTipText(@Nonnull JTabbedPane tabbedPane, @Nullable String toolTipText, @Nonnull Index index) {
+    String actualToolTipText = toolTipTextAt(tabbedPane, index);
+    verifyThat(actualToolTipText).as(toolTipTextAtProperty(tabbedPane)).isEqualOrMatches(toolTipText);
+  }
+
+  /**
+   * Asserts that the toolTipText of the tab at the given index matches the given regular expression pattern.
+   *
+   * @param tabbedPane the target {@code JTabbedPane}.
+   * @param pattern the regular expression pattern to match.
+   * @param index the index of the tab.
+   * @throws NullPointerException if the given regular expression pattern is {@code null}.
+   * @throws IndexOutOfBoundsException if the given index is not within the {@code JTabbedPane} bounds.
+   * @throws AssertionError if the toolTipText of the tab at the given index does not match the given one.
+   */
+  @RunsInEDT
+  public void requireTabToolTipText(@Nonnull JTabbedPane tabbedPane, @Nonnull Pattern pattern, @Nonnull Index index) {
+    String actualToolTipText = toolTipTextAt(tabbedPane, index);
+    verifyThat(actualToolTipText).as(toolTipTextAtProperty(tabbedPane)).matches(pattern);
+  }
+
+  /**
+   * Asserts that the tab at the given index is enabled.
+   *
+   * @param tabbedPane the target {@code JTabbedPane}.
+   * @param index the index of the tab.
+   * @throws IndexOutOfBoundsException if the given index is not within the {@code JTabbedPane} bounds.
+   * @throws AssertionError if the tab at the given index is not enabled.
+   */
+  @RunsInEDT
+  public void requireTabEnabled(@Nonnull JTabbedPane tabbedPane, @Nonnull Index index) {
+    boolean actualEnabled = isEnabledAt(tabbedPane, index);
+    assertThat(actualEnabled).as(enabledAtProperty(tabbedPane)).isTrue();
+  }
+
+  /**
+   * Asserts that the tab at the given index is disabled.
+   *
+   * @param tabbedPane the target {@code JTabbedPane}.
+   * @param index the index of the tab.
+   * @throws IndexOutOfBoundsException if the given index is not within the {@code JTabbedPane} bounds.
+   * @throws AssertionError if the tab at the given index is not disabled.
+   */
+  @RunsInEDT
+  public void requireTabDisabled(@Nonnull JTabbedPane tabbedPane, @Nonnull Index index) {
+    boolean actualEnabled = isEnabledAt(tabbedPane, index);
+    assertThat(actualEnabled).as(enabledAtProperty(tabbedPane)).isFalse();
+  }
+
   @RunsInEDT
   private Description titleAtProperty(@Nonnull JTabbedPane tabbedPane) {
     return propertyName(tabbedPane, "titleAt");
   }
 
   @RunsInEDT
+  private Description toolTipTextAtProperty(@Nonnull JTabbedPane tabbedPane) {
+    return propertyName(tabbedPane, "toolTipTextAt");
+  }
+
+  @RunsInEDT
+  private Description enabledAtProperty(@Nonnull JTabbedPane tabbedPane) {
+    return propertyName(tabbedPane, "enabledAt");
+  }
+
+  @RunsInEDT
   private static @Nullable String titleAt(final @Nonnull JTabbedPane tabbedPane, final @Nonnull Index index) {
     return execute(() -> tabbedPane.getTitleAt(index.value));
+  }
+
+  @RunsInEDT
+  private static @Nullable String toolTipTextAt(final @Nonnull JTabbedPane tabbedPane, final @Nonnull Index index) {
+    return execute(() -> tabbedPane.getToolTipTextAt(index.value));
+  }
+
+  @RunsInEDT
+  private static @Nullable boolean isEnabledAt(final @Nonnull JTabbedPane tabbedPane, final @Nonnull Index index) {
+    return execute(() -> tabbedPane.isEnabledAt(index.value));
   }
 
   /**

--- a/assertj-swing/src/main/java/org/assertj/swing/fixture/JTabbedPaneFixture.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/fixture/JTabbedPaneFixture.java
@@ -27,6 +27,7 @@ import org.assertj.swing.driver.JTabbedPaneDriver;
  *
  * @author Alex Ruiz
  * @author Yvonne Wang
+ * @author William Bakker
  */
 public class JTabbedPaneFixture extends
     AbstractJPopupMenuInvokerFixture<JTabbedPaneFixture, JTabbedPane, JTabbedPaneDriver> {
@@ -163,6 +164,61 @@ public class JTabbedPaneFixture extends
    */
   public @Nonnull JTabbedPaneFixture requireSelectedTab(@Nonnull Index expected) {
     driver().requireSelectedTab(target(), expected);
+    return this;
+  }
+
+  /**
+   * Asserts that the toolTipText of the tab at the given index matches the given value.
+   *
+   * @param toolTipText the expected toolTipText. It can be a regular expression.
+   * @param index the index of the tab.
+   * @return this fixture.
+   * @throws IndexOutOfBoundsException if the given index is not within the {@code JTabbedPane} bounds.
+   * @throws AssertionError if the toolTipText of the tab at the given index does not match the given one.
+   */
+  public @Nonnull JTabbedPaneFixture requireToolTipText(@Nullable String toolTipText, @Nonnull Index index) {
+    driver().requireTabToolTipText(target(), toolTipText, index);
+    return this;
+  }
+
+  /**
+   * Asserts that the toolTipText of the tab at the given index matches the given regular expression pattern.
+   *
+   * @param pattern the regular expression pattern to match.
+   * @param index the index of the tab.
+   * @return this fixture.
+   * @throws NullPointerException if the given regular expression pattern is {@code null}.
+   * @throws AssertionError if the toolTipText of the tab at the given index does not match the given regular expression
+   *           pattern.
+   */
+  public @Nonnull JTabbedPaneFixture requireToolTipText(@Nonnull Pattern pattern, @Nonnull Index index) {
+    driver().requireTabToolTipText(target(), pattern, index);
+    return this;
+  }
+
+  /**
+   * Asserts that the tab at the given index is enabled.
+   *
+   * @param index the index of the tab.
+   * @return this fixture.
+   * @throws IndexOutOfBoundsException if the given index is not within the {@code JTabbedPane} bounds.
+   * @throws AssertionError if the tab at the given index is not enabled.
+   */
+  public @Nonnull JTabbedPaneFixture requireEnabled(@Nonnull Index index) {
+    driver().requireTabEnabled(target(), index);
+    return this;
+  }
+
+  /**
+   * Asserts that the tab at the given index is disabled.
+   *
+   * @param index the index of the tab.
+   * @return this fixture.
+   * @throws IndexOutOfBoundsException if the given index is not within the {@code JTabbedPane} bounds.
+   * @throws AssertionError if the tab at the given index is not disabled.
+   */
+  public @Nonnull JTabbedPaneFixture requireDisabled(@Nonnull Index index) {
+    driver().requireTabDisabled(target(), index);
     return this;
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_TestCase.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_TestCase.java
@@ -33,6 +33,7 @@ import org.junit.Rule;
  * 
  * @author Alex Ruiz
  * @author Yvonne Wang
+ * @author William Bakker
  */
 public abstract class JTabbedPaneDriver_TestCase extends RobotBasedTestCase {
   JTabbedPaneDriver driver;
@@ -83,8 +84,10 @@ public abstract class JTabbedPaneDriver_TestCase extends RobotBasedTestCase {
 
     private MyWindow(Class<?> testClass) {
       super(testClass);
-      tabbedPane.addTab("One", panelWithName("panel1"));
-      tabbedPane.addTab("Two", panelWithName("panel2"));
+      tabbedPane.addTab("One", null, panelWithName("panel1"), "tip1");
+      tabbedPane.addTab("Two", null, panelWithName("panel2"), "tip2");
+      tabbedPane.addTab("Three", null, panelWithName("panel3"), "tip3");
+      tabbedPane.setEnabledAt(tabbedPane.indexOfTab("Three"), false);
       add(tabbedPane);
       setPreferredSize(new Dimension(100, 100));
     }

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabDisabled_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabDisabled_Test.java
@@ -12,19 +12,26 @@
  */
 package org.assertj.swing.driver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Arrays.array;
-
 import org.junit.Test;
 
+import static org.assertj.swing.data.Index.atIndex;
+
 /**
- * Tests for {@link JTabbedPaneDriver#tabTitles(javax.swing.JTabbedPane)}.
+ * Tests for {@link JTabbedPaneDriver#requireTabDisabled(javax.swing.JTabbedPane, org.assertj.swing.data.Index)}.
  * 
- * @author Alex Ruiz
+ * @author William Bakker
  */
-public class JTabbedPaneDriver_tabTitles_Test extends JTabbedPaneDriver_TestCase {
+public class JTabbedPaneDriver_requireTabDisabled_Test extends JTabbedPaneDriver_TestCase {
   @Test
-  public void should_Return_Tab_Titles() {
-    assertThat(driver.tabTitles(tabbedPane)).isEqualTo(array("One", "Two", "Three"));
+  public void should_Fail_If_Tab_Is_Enabled() {
+    thrown.expectAssertionError("property:'enabledAt'");
+    thrown.expectMessageToContain("expected:<[fals]e> but was:<[tru]e>");
+
+    driver.requireTabDisabled(tabbedPane, atIndex(0));
+  }
+
+  @Test
+  public void should_Pass_If_Tab_Is_Disabled() {
+    driver.requireTabDisabled(tabbedPane, atIndex(2));
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabEnabled_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabEnabled_Test.java
@@ -12,19 +12,26 @@
  */
 package org.assertj.swing.driver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Arrays.array;
-
 import org.junit.Test;
 
+import static org.assertj.swing.data.Index.atIndex;
+
 /**
- * Tests for {@link JTabbedPaneDriver#tabTitles(javax.swing.JTabbedPane)}.
+ * Tests for {@link JTabbedPaneDriver#requireTabEnabled(javax.swing.JTabbedPane, org.assertj.swing.data.Index)}.
  * 
- * @author Alex Ruiz
+ * @author William Bakker
  */
-public class JTabbedPaneDriver_tabTitles_Test extends JTabbedPaneDriver_TestCase {
+public class JTabbedPaneDriver_requireTabEnabled_Test extends JTabbedPaneDriver_TestCase {
   @Test
-  public void should_Return_Tab_Titles() {
-    assertThat(driver.tabTitles(tabbedPane)).isEqualTo(array("One", "Two", "Three"));
+  public void should_Fail_If_Tab_Is_Disabled() {
+    thrown.expectAssertionError("property:'enabledAt'");
+    thrown.expectMessageToContain("expected:<[tru]e> but was:<[fals]e>");
+
+    driver.requireTabEnabled(tabbedPane, atIndex(2));
+  }
+
+  @Test
+  public void should_Pass_If_Tab_Is_Enabled() {
+    driver.requireTabEnabled(tabbedPane, atIndex(0));
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabTitles_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabTitles_Test.java
@@ -24,12 +24,12 @@ import org.junit.Test;
 public class JTabbedPaneDriver_requireTabTitles_Test extends JTabbedPaneDriver_TestCase {
   @Test
   public void should_Fail_If_Titles_Are_Not_Equal_To_Expected() {
-    thrown.expectAssertionError("tabTitles", array("[Three", "Four]"), array("[One", "Two]"));
-    driver.requireTabTitles(tabbedPane, array("Three", "Four"));
+    thrown.expectAssertionError("tabTitles", array("[Four", "Fiv]e"), array("[One", "Two", "Thre]e"));
+    driver.requireTabTitles(tabbedPane, array("Four", "Five"));
   }
 
   @Test
   public void should_Pass_If_Titles_Are_Equal_To_Expected() {
-    driver.requireTabTitles(tabbedPane, array("One", "Two"));
+    driver.requireTabTitles(tabbedPane, array("One", "Two", "Three"));
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabToolTipTextAsPattern_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabToolTipTextAsPattern_Test.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.swing.driver;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.swing.data.Index.atIndex;
+
+/**
+ * Tests for
+ * {@link JTabbedPaneDriver#requireTabToolTipText(javax.swing.JTabbedPane, Pattern, org.assertj.swing.data.Index)}
+ *
+ * @author William Bakker
+ */
+public class JTabbedPaneDriver_requireTabToolTipTextAsPattern_Test extends JTabbedPaneDriver_TestCase {
+  @Test
+  public void should_Fail_If_ToolTipText_Does_Not_Match_Pattern() {
+    thrown.expectAssertionError("toolTipTextAt", "tip1", Pattern.compile("Hello"));
+    driver.requireTabToolTipText(tabbedPane, Pattern.compile("Hello"), atIndex(0));
+  }
+
+  @Test
+  public void should_Pass_If_ToolTipText_Matches_Pattern() {
+    driver.requireTabToolTipText(tabbedPane, Pattern.compile("t.*"), atIndex(0));
+  }
+}

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabToolTipTextAsText_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_requireTabToolTipTextAsText_Test.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.swing.driver;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.swing.data.Index.atIndex;
+
+/**
+ * Tests for {@link JTabbedPaneDriver#requireTabToolTipText(javax.swing.JTabbedPane, String, org.assertj.swing.data.Index)}.
+ * 
+ * @author William Bakker
+ */
+public class JTabbedPaneDriver_requireTabToolTipTextAsText_Test extends JTabbedPaneDriver_TestCase {
+  @Test
+  public void should_Fail_If_ToolTipText_Is_Not_Equal_To_Expected() {
+    thrown.expectAssertionError("toolTipTextAt", "tip1", Pattern.compile("Hello"));
+    driver.requireTabToolTipText(tabbedPane, "Hello", atIndex(0));
+  }
+
+  @Test
+  public void should_Pass_If_ToolTipText_Is_Equal_To_Expected() {
+    driver.requireTabToolTipText(tabbedPane, "tip1", atIndex(0));
+  }
+
+  @Test
+  public void should_Pass_If_ToolTipText_Matches_Pattern() {
+    driver.requireTabToolTipText(tabbedPane, "t.*", atIndex(0));
+  }
+}

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_selectTabByIndex_withInvalidIndices_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JTabbedPaneDriver_selectTabByIndex_withInvalidIndices_Test.java
@@ -34,7 +34,7 @@ public class JTabbedPaneDriver_selectTabByIndex_withInvalidIndices_Test extends 
 
   @Parameters
   public static Collection<Object[]> indices() {
-    return newArrayList(new Object[][] { { -1 }, { 2 } });
+    return newArrayList(new Object[][] { { -1 }, { 3 } });
   }
 
   public JTabbedPaneDriver_selectTabByIndex_withInvalidIndices_Test(int index) {
@@ -44,7 +44,7 @@ public class JTabbedPaneDriver_selectTabByIndex_withInvalidIndices_Test extends 
   @Test
   public void should_Throw_Error_If_Index_Is_Out_Of_Bounds() {
     thrown.expectIndexOutOfBoundsException(concat("Index <", index,
-        "> is not within the JTabbedPane bounds of <0> and <1> (inclusive)"));
+        "> is not within the JTabbedPane bounds of <0> and <2> (inclusive)"));
     driver.selectTab(tabbedPane, index);
   }
 }

--- a/assertj-swing/src/test/java/org/assertj/swing/fixture/JTabbedPaneFixture_withMocks_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/fixture/JTabbedPaneFixture_withMocks_Test.java
@@ -32,6 +32,7 @@ import org.junit.Test;
  * 
  * @author Alex Ruiz
  * @author Yvonne Wang
+ * @author William Bakker
  */
 public class JTabbedPaneFixture_withMocks_Test {
   private JTabbedPaneFixture fixture;
@@ -89,5 +90,36 @@ public class JTabbedPaneFixture_withMocks_Test {
     String[] titles = { "One", "Two" };
     assertThat(fixture.requireTabTitles(titles)).isSameAs(fixture);
     verify(fixture.driver()).requireTabTitles(fixture.target(), titles);
+  }
+
+  @Test
+  public void should_Call_RequireSelectedTab_In_Driver_And_Return_Self() {
+    assertThat(fixture.requireSelectedTab(atIndex(6))).isSameAs(fixture);
+    verify(fixture.driver()).requireSelectedTab(fixture.target(), atIndex(6));
+  }
+
+  @Test
+  public void should_Call_RequireToolTipText_With_Text_In_Driver_And_Return_Self() {
+    assertThat(fixture.requireToolTipText("Hello", atIndex(6))).isSameAs(fixture);
+    verify(fixture.driver()).requireTabToolTipText(fixture.target(), "Hello", atIndex(6));
+  }
+
+  @Test
+  public void should_Call_RequireToolTipText_With_Pattern_In_Driver_And_Return_Self() {
+    Pattern pattern = Pattern.compile("Hello");
+    assertThat(fixture.requireToolTipText(pattern, atIndex(6))).isSameAs(fixture);
+    verify(fixture.driver()).requireTabToolTipText(fixture.target(), pattern, atIndex(6));
+  }
+
+  @Test
+  public void should_Call_RequireEnabled_In_Driver_And_Return_Self() {
+    assertThat(fixture.requireEnabled(atIndex(6))).isSameAs(fixture);
+    verify(fixture.driver()).requireTabEnabled(fixture.target(), atIndex(6));
+  }
+
+  @Test
+  public void should_Call_RequireDisabled_In_Driver_And_Return_Self() {
+    assertThat(fixture.requireDisabled(atIndex(6))).isSameAs(fixture);
+    verify(fixture.driver()).requireTabDisabled(fixture.target(), atIndex(6));
   }
 }


### PR DESCRIPTION
Additional functionality added to JTabbedPaneDriver and JTabbedPaneFixture:

* RequireTabToolTipText(JTabbedPane, String, Index)
* RequireTabToolTipText(JTabbedPane, Pattern, Index)
* RequireTabEnabled(JTabbedPane, Index)
* RequireTabDisabled(JTabbedPane, Index)