### PR TITLE
Made AbstractComponentFixture.robot() public

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/fixture/AbstractComponentFixture.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/fixture/AbstractComponentFixture.java
@@ -483,7 +483,7 @@ public abstract class AbstractComponentFixture<S, C extends Component, D extends
   }
 
   /** @return the {@link Robot} that simulates user events on {@link #target()}. */
-  protected final @Nonnull Robot robot() {
+  public final @Nonnull Robot robot() {
     return robot;
   }
 


### PR DESCRIPTION
It is desirable to be able to factor out code that operates on
component fixtures without having to pass the Robot as a separate
argument.

Another use case: In Kotlin, you can define extension functions on
component fixtures to add custom functionality. Often a robot is
required. With this change you could define:

    fun AbstractComponentFixture<*, *, *>.clickTopLeftCorner() {
        robot().click(target(), Point(0, 0))
    }