### PR TITLE
Make 2.2.x compile with assertj-core:2.8.0

### DIFF
--- a/assertj-swing/pom.xml
+++ b/assertj-swing/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>2.8.0</version>
     </dependency>
 
     <dependency>

--- a/assertj-swing/src/main/java/org/assertj/swing/applet/BasicAppletContext.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/applet/BasicAppletContext.java
@@ -14,7 +14,6 @@ package org.assertj.swing.applet;
 
 import static java.util.Collections.enumeration;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.applet.Applet;
@@ -24,6 +23,7 @@ import java.awt.Image;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -54,7 +54,7 @@ public class BasicAppletContext implements AppletContext {
     }
   }
 
-  private final Map<String, InputStream> streamMap = newHashMap();
+  private final Map<String, InputStream> streamMap = new HashMap<>();
   private final StatusDisplay statusDisplay;
 
   /**

--- a/assertj-swing/src/main/java/org/assertj/swing/applet/BasicAppletStub.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/applet/BasicAppletStub.java
@@ -12,13 +12,13 @@
  */
 package org.assertj.swing.applet;
 
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.applet.AppletContext;
 import java.applet.AppletStub;
 import java.awt.Window;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 public class BasicAppletStub implements AppletStub {
   private final Window viewer;
   private final AppletContext context;
-  private final Map<String, String> parameters = newHashMap();
+  private final Map<String, String> parameters = new HashMap<>();
 
   /**
    * Creates a new {@link BasicAppletStub}.

--- a/assertj-swing/src/main/java/org/assertj/swing/driver/JOptionPaneMessageTypes.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/driver/JOptionPaneMessageTypes.java
@@ -17,11 +17,11 @@ import static javax.swing.JOptionPane.INFORMATION_MESSAGE;
 import static javax.swing.JOptionPane.PLAIN_MESSAGE;
 import static javax.swing.JOptionPane.QUESTION_MESSAGE;
 import static javax.swing.JOptionPane.WARNING_MESSAGE;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNullOrEmpty;
 import static org.assertj.core.util.Strings.concat;
 import static org.assertj.swing.exception.ActionFailedException.actionFailure;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -32,7 +32,7 @@ import javax.annotation.Nonnull;
  * @author Alex Ruiz
  */
 final class JOptionPaneMessageTypes {
-  private static final Map<Integer, String> messageMap = newHashMap();
+  private static final Map<Integer, String> messageMap = new HashMap<>();
   static {
     messageMap.put(ERROR_MESSAGE, "Error Message");
     messageMap.put(INFORMATION_MESSAGE, "Information Message");

--- a/assertj-swing/src/main/java/org/assertj/swing/driver/JScrollBarLocation.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/driver/JScrollBarLocation.java
@@ -14,10 +14,10 @@ package org.assertj.swing.driver;
 
 import static java.awt.Adjustable.HORIZONTAL;
 import static java.awt.Adjustable.VERTICAL;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.awt.Point;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -36,7 +36,7 @@ public final class JScrollBarLocation {
 
   private static final int BLOCK_OFFSET = 4;
 
-  private static final Map<Integer, JScrollBarLocationStrategy> LOCATIONS = newHashMap();
+  private static final Map<Integer, JScrollBarLocationStrategy> LOCATIONS = new HashMap<>();
 
   static {
     LOCATIONS.put(HORIZONTAL, new HorizontalJScrollBarLocation());

--- a/assertj-swing/src/main/java/org/assertj/swing/driver/JSliderLocation.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/driver/JSliderLocation.java
@@ -14,11 +14,11 @@ package org.assertj.swing.driver;
 
 import static javax.swing.SwingConstants.HORIZONTAL;
 import static javax.swing.SwingConstants.VERTICAL;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.awt.Insets;
 import java.awt.Point;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -33,7 +33,7 @@ import org.assertj.swing.annotation.RunsInCurrentThread;
  * @author Yvonne Wang
  */
 public final class JSliderLocation {
-  private static final Map<Integer, JSliderLocationStrategy> LOCATIONS = newHashMap();
+  private static final Map<Integer, JSliderLocationStrategy> LOCATIONS = new HashMap<>();
 
   static {
     LOCATIONS.put(HORIZONTAL, new JSliderHorizontalLocation());

--- a/assertj-swing/src/main/java/org/assertj/swing/driver/JSplitPaneLocationCalculator.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/driver/JSplitPaneLocationCalculator.java
@@ -16,12 +16,12 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static javax.swing.JSplitPane.HORIZONTAL_SPLIT;
 import static javax.swing.JSplitPane.VERTICAL_SPLIT;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.swing.edt.GuiActionRunner.execute;
 
 import java.awt.Component;
 import java.awt.Insets;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -39,7 +39,7 @@ import org.assertj.swing.edt.GuiQuery;
  * @author Alex Ruiz
  */
 final class JSplitPaneLocationCalculator {
-  private static Map<Integer, LocationFinder> FINDERS = newHashMap();
+  private static Map<Integer, LocationFinder> FINDERS = new HashMap<>();
 
   static {
     add(new VerticalOrientationLocationFinder(), new HorizontalOrientationLocationFinder());

--- a/assertj-swing/src/main/java/org/assertj/swing/edt/GuiActionRunner.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/edt/GuiActionRunner.java
@@ -14,7 +14,7 @@ package org.assertj.swing.edt;
 
 import static javax.swing.SwingUtilities.invokeLater;
 import static javax.swing.SwingUtilities.isEventDispatchThread;
-import static org.assertj.core.util.Throwables.appendStackTraceInCurentThreadToThrowable;
+import static org.assertj.core.util.Throwables.appendStackTraceInCurrentThreadToThrowable;
 import static org.assertj.swing.exception.UnexpectedException.unexpected;
 
 import java.util.concurrent.CountDownLatch;
@@ -146,7 +146,7 @@ public class GuiActionRunner {
       return;
     }
     if (caughtException instanceof RuntimeException) {
-      appendStackTraceInCurentThreadToThrowable(caughtException, "execute");
+      appendStackTraceInCurrentThreadToThrowable(caughtException, "execute");
       throw (RuntimeException) caughtException;
     }
     if (caughtException instanceof Error) {

--- a/assertj-swing/src/main/java/org/assertj/swing/format/Formatting.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/format/Formatting.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.swing.format;
 
-import static org.assertj.core.util.Maps.newConcurrentHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Strings.isNullOrEmpty;
 import static org.assertj.swing.edt.GuiActionRunner.execute;
@@ -20,6 +19,7 @@ import static org.assertj.swing.edt.GuiActionRunner.execute;
 import java.awt.Component;
 import java.awt.Dialog;
 import java.awt.Frame;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 
@@ -66,7 +66,7 @@ public class Formatting {
   private static final String VALUE = "value";
   private static final String VISIBLE = "visible";
 
-  private static final ConcurrentMap<Class<?>, ComponentFormatter> FORMATTERS = newConcurrentHashMap();
+  private static final ConcurrentMap<Class<?>, ComponentFormatter> FORMATTERS = new ConcurrentHashMap<>();
 
   private static Logger logger = Logger.getLogger(Formatting.class.getCanonicalName());
 

--- a/assertj-swing/src/main/java/org/assertj/swing/format/IntEnum.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/format/IntEnum.java
@@ -13,8 +13,8 @@
 package org.assertj.swing.format;
 
 import static java.lang.String.valueOf;
-import static org.assertj.core.util.Maps.newHashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  * @author Alex Ruiz
  */
 final class IntEnum {
-  private final Map<Integer, String> map = newHashMap();
+  private final Map<Integer, String> map = new HashMap<>();
 
   @Nullable
   String get(int key) {

--- a/assertj-swing/src/main/java/org/assertj/swing/format/IntrospectionComponentFormatter.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/format/IntrospectionComponentFormatter.java
@@ -13,7 +13,6 @@
 package org.assertj.swing.format;
 
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Strings.concat;
 import static org.assertj.core.util.Strings.quote;
@@ -23,6 +22,7 @@ import java.awt.Component;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +44,7 @@ public final class IntrospectionComponentFormatter extends ComponentFormatterTem
   private final Class<? extends Component> targetType;
   private final List<String> propertyNames;
 
-  private final Map<String, PropertyDescriptor> descriptors = newHashMap();
+  private final Map<String, PropertyDescriptor> descriptors = new HashMap<>();
 
   /**
    * Creates a new {@link IntrospectionComponentFormatter}.

--- a/assertj-swing/src/main/java/org/assertj/swing/hierarchy/WindowFilter.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/hierarchy/WindowFilter.java
@@ -12,13 +12,13 @@
  */
 package org.assertj.swing.hierarchy;
 
-import static org.assertj.core.util.Maps.newWeakHashMap;
 import static org.assertj.swing.awt.AWT.isSharedInvisibleFrame;
 
 import java.awt.Component;
 import java.awt.Window;
 import java.util.Collection;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,10 +44,10 @@ class WindowFilter {
   }
 
   // Map of components to ignore
-  final Map<Component, Boolean> ignored = newWeakHashMap();
+  final Map<Component, Boolean> ignored = new WeakHashMap<>();
 
   // Map of components implicitly ignored; these will be removed if they are re-shown.
-  final Map<Component, Boolean> implicitlyIgnored = newWeakHashMap();
+  final Map<Component, Boolean> implicitlyIgnored = new WeakHashMap<>();
 
   boolean isImplicitlyIgnored(@Nonnull Component c) {
     return implicitlyIgnored.containsKey(c);

--- a/assertj-swing/src/main/java/org/assertj/swing/input/DisposedWindowMonitor.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/input/DisposedWindowMonitor.java
@@ -14,12 +14,12 @@ package org.assertj.swing.input;
 
 import static java.awt.event.WindowEvent.WINDOW_CLOSED;
 import static java.awt.event.WindowEvent.WINDOW_CLOSING;
-import static org.assertj.core.util.Maps.newWeakHashMap;
 
 import java.awt.AWTEvent;
 import java.awt.Window;
 import java.awt.event.WindowEvent;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * Verifies that a notification of the disposal of an AWT or Swing {@code Window} is not duplicated.
@@ -27,7 +27,7 @@ import java.util.Map;
  * @author Alex Ruiz
  */
 class DisposedWindowMonitor {
-  final Map<Window, Boolean> disposedWindows = newWeakHashMap();
+  final Map<Window, Boolean> disposedWindows = new WeakHashMap<>();
 
   // We want to ignore consecutive event indicating window disposal; it needs to be an intervening SHOWN/OPEN before
   // we're interested again.

--- a/assertj-swing/src/main/java/org/assertj/swing/keystroke/KeyStrokeMapCollection.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/keystroke/KeyStrokeMapCollection.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.swing.keystroke;
 
-import static org.assertj.core.util.Maps.newHashMap;
-
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -26,8 +25,8 @@ import javax.swing.KeyStroke;
  * @author Alex Ruiz
  */
 class KeyStrokeMapCollection {
-  private final Map<Character, KeyStroke> charToKeyStroke = newHashMap();
-  private final Map<KeyStroke, Character> keyStrokeToChar = newHashMap();
+  private final Map<Character, KeyStroke> charToKeyStroke = new HashMap<>();
+  private final Map<KeyStroke, Character> keyStrokeToChar = new HashMap<>();
 
   void add(@Nonnull Character character, @Nonnull KeyStroke keyStroke) {
     charToKeyStroke.put(character, keyStroke);

--- a/assertj-swing/src/main/java/org/assertj/swing/keystroke/KeyStrokeMappingsParser.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/keystroke/KeyStrokeMappingsParser.java
@@ -16,7 +16,6 @@ import static java.lang.Thread.currentThread;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Closeables.closeQuietly;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Preconditions.checkNotNullOrEmpty;
 import static org.assertj.core.util.Strings.concat;
@@ -34,6 +33,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -96,7 +96,7 @@ import org.fest.reflect.exception.ReflectionError;
  * @author Alex Ruiz
  */
 public class KeyStrokeMappingsParser {
-  private static final Map<String, Character> SPECIAL_MAPPINGS = newHashMap();
+  private static final Map<String, Character> SPECIAL_MAPPINGS = new HashMap<>();
 
   static {
     SPECIAL_MAPPINGS.put("COMMA", ',');

--- a/assertj-swing/src/main/java/org/assertj/swing/launcher/AppletLauncher.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/launcher/AppletLauncher.java
@@ -12,13 +12,13 @@
  */
 package org.assertj.swing.launcher;
 
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Preconditions.checkNotNullOrEmpty;
 import static org.assertj.swing.edt.GuiActionRunner.execute;
 import static org.assertj.swing.launcher.NewAppletViewerQuery.showAppletViewerWith;
 
 import java.applet.Applet;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -81,7 +81,7 @@ import org.assertj.swing.exception.UnexpectedException;
  */
 public class AppletLauncher {
   private final Applet applet;
-  private final Map<String, String> parameters = newHashMap();
+  private final Map<String, String> parameters = new HashMap<>();
 
   /**
    * Creates a new {@link AppletLauncher}. The {@code Applet} to launch is a new instance of the given type. It is

--- a/assertj-swing/src/main/java/org/assertj/swing/monitor/EventQueueMapping.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/monitor/EventQueueMapping.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.swing.monitor;
 
-import static org.assertj.core.util.Maps.newWeakHashMap;
 import static org.assertj.core.util.Sets.newHashSet;
 
 import java.awt.Component;
@@ -21,6 +20,7 @@ import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,7 +34,7 @@ import org.assertj.swing.annotation.RunsInCurrentThread;
  * @author Alex Ruiz
  */
 class EventQueueMapping {
-  final Map<Component, WeakReference<EventQueue>> queueMap = newWeakHashMap();
+  final Map<Component, WeakReference<EventQueue>> queueMap = new WeakHashMap<>();
 
   @RunsInCurrentThread
   void addQueueFor(@Nonnull Component c) {

--- a/assertj-swing/src/main/java/org/assertj/swing/monitor/WindowEventQueueMapping.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/monitor/WindowEventQueueMapping.java
@@ -13,7 +13,6 @@
 package org.assertj.swing.monitor;
 
 import static java.lang.Boolean.TRUE;
-import static org.assertj.core.util.Maps.newWeakHashMap;
 import static org.assertj.core.util.Sets.newHashSet;
 import static org.assertj.swing.query.ComponentParentQuery.parentOf;
 
@@ -24,6 +23,7 @@ import java.awt.Window;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import javax.annotation.Nonnull;
 
@@ -36,10 +36,10 @@ import org.assertj.swing.annotation.RunsInCurrentThread;
  * @author Yvonne Wang
  */
 class WindowEventQueueMapping {
-  final Map<EventQueue, Map<Window, Boolean>> queueMap = newWeakHashMap();
+  final Map<EventQueue, Map<Window, Boolean>> queueMap = new WeakHashMap<>();
 
   void addQueueFor(@Nonnull Toolkit toolkit) {
-    Map<Window, Boolean> map = newWeakHashMap();
+    Map<Window, Boolean> map = new WeakHashMap<>();
     queueMap.put(toolkit.getSystemEventQueue(), map);
   }
 
@@ -56,7 +56,7 @@ class WindowEventQueueMapping {
   }
 
   private @Nonnull Map<Window, Boolean> createWindowMapping(EventQueue queue) {
-    Map<Window, Boolean> windowMapping = newWeakHashMap();
+    Map<Window, Boolean> windowMapping = new WeakHashMap<>();
     queueMap.put(queue, windowMapping);
     return windowMapping;
   }

--- a/assertj-swing/src/main/java/org/assertj/swing/monitor/Windows.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/monitor/Windows.java
@@ -12,13 +12,12 @@
  */
 package org.assertj.swing.monitor;
 
-import static org.assertj.core.util.Maps.newWeakHashMap;
-
 import java.awt.Component;
 import java.awt.Window;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.WeakHashMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
@@ -39,19 +38,19 @@ class Windows {
 
   /** {@link Window#isShowing() isShowing} is true but are not yet ready for input. */
   @GuardedBy("lock")
-  final Map<Window, TimerTask> pending = newWeakHashMap();
+  final Map<Window, TimerTask> pending = new WeakHashMap<>();
 
   /** Considered to be ready to use. */
   @GuardedBy("lock")
-  final Map<Window, Boolean> open = newWeakHashMap();
+  final Map<Window, Boolean> open = new WeakHashMap<>();
 
   /** Have sent a {@link java.awt.event.WindowEvent#WINDOW_CLOSED WINDOW_CLOSED} event. */
   @GuardedBy("lock")
-  final Map<Window, Boolean> closed = newWeakHashMap();
+  final Map<Window, Boolean> closed = new WeakHashMap<>();
 
   /** Not visible. */
   @GuardedBy("lock")
-  final Map<Window, Boolean> hidden = newWeakHashMap();
+  final Map<Window, Boolean> hidden = new WeakHashMap<>();
 
   private final Timer windowReadyTimer;
 

--- a/assertj-swing/src/main/java/org/assertj/swing/text/TextReaders.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/text/TextReaders.java
@@ -12,13 +12,13 @@
  */
 package org.assertj.swing.text;
 
-import static org.assertj.core.util.Maps.newConcurrentHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Strings.concat;
 import static org.assertj.swing.edt.GuiActionRunner.execute;
 
 import java.awt.Component;
 import java.awt.Container;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 
@@ -38,7 +38,7 @@ public class TextReaders {
   private static Logger logger = Logger.getLogger(TextReaders.class.getCanonicalName());
 
   @VisibleForTesting
-  final ConcurrentMap<Class<?>, TextReader<?>> readers = newConcurrentHashMap();
+  final ConcurrentMap<Class<?>, TextReader<?>> readers = new ConcurrentHashMap<>();
 
   @VisibleForTesting
   TextReaders() {

--- a/assertj-swing/src/main/java/org/assertj/swing/util/Arrays.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/util/Arrays.java
@@ -71,7 +71,7 @@ public final class Arrays {
 
   @InternalApi
   public static String format(Object object) {
-    return org.assertj.core.util.Arrays.format(new StandardRepresentation(), object);
+    return new StandardRepresentation().toStringOf( object );
   }
 
   /**

--- a/assertj-swing/src/test/java/org/assertj/swing/applet/BasicAppletStub_getParameter_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/applet/BasicAppletStub_getParameter_Test.java
@@ -13,8 +13,8 @@
 package org.assertj.swing.applet;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Maps.newHashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class BasicAppletStub_getParameter_Test extends BasicAppletStub_TestCase {
   @Test
   public void should_Return_Parameter() {
-    Map<String, String> parameters = newHashMap();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("key1", "value1");
     stub = new BasicAppletStub(viewer, context, parameters);
     assertThat(stub.getParameter("key1")).isEqualTo("value1");

--- a/assertj-swing/src/test/java/org/assertj/swing/driver/JAppletDriver_TestCase.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/driver/JAppletDriver_TestCase.java
@@ -13,7 +13,6 @@
 package org.assertj.swing.driver;
 
 import static javax.swing.SwingUtilities.isEventDispatchThread;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Strings.concat;
 import static org.assertj.core.util.Strings.quote;
 import static org.assertj.swing.core.TestRobots.singletonRobotMock;
@@ -21,6 +20,7 @@ import static org.assertj.swing.edt.GuiActionRunner.execute;
 
 import java.applet.AppletContext;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.JApplet;
@@ -55,8 +55,8 @@ public class JAppletDriver_TestCase extends EDTSafeTestCase {
   }
 
   static class JAppletStub extends JApplet {
-    private final Map<String, Boolean> methodCallsInEDT = newHashMap();
-    private final Map<String, String> parameters = newHashMap();
+    private final Map<String, Boolean> methodCallsInEDT = new HashMap<>();
+    private final Map<String, String> parameters = new HashMap<>();
 
     private AppletContext context;
     private URL codeBase;

--- a/assertj-swing/src/test/java/org/assertj/swing/input/DisposalMonitor_componentShown_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/input/DisposalMonitor_componentShown_Test.java
@@ -13,10 +13,10 @@
 package org.assertj.swing.input;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Maps.newHashMap;
 
 import java.awt.Window;
 import java.awt.event.ComponentEvent;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.JFrame;
@@ -38,7 +38,7 @@ public class DisposalMonitor_componentShown_Test {
   @Before
   public void setUp() {
     frame = TestWindow.createNewWindow(DisposalMonitor_componentShown_Test.class);
-    disposedWindows = newHashMap();
+    disposedWindows = new HashMap<>();
     monitor = new DisposalMonitor(disposedWindows);
     frame.addComponentListener(monitor);
   }

--- a/assertj-swing/src/test/java/org/assertj/swing/keystroke/KeyStrokeMappingProvider_TestCase.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/keystroke/KeyStrokeMappingProvider_TestCase.java
@@ -19,13 +19,13 @@ import static java.awt.event.KeyEvent.VK_ESCAPE;
 import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Strings.concat;
 import static org.assertj.core.util.Strings.quote;
 import static org.assertj.swing.timing.Pause.pause;
 
 import java.awt.Dimension;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +49,7 @@ import org.junit.Test;
  * @author Alex Ruiz
  */
 public abstract class KeyStrokeMappingProvider_TestCase extends RobotBasedTestCase {
-  private static final Map<Character, Integer> BASIC_CHARS_AND_KEYS_MAP = newHashMap();
+  private static final Map<Character, Integer> BASIC_CHARS_AND_KEYS_MAP = new HashMap<>();
 
   static {
     BASIC_CHARS_AND_KEYS_MAP.put((char) 8, VK_BACK_SPACE);

--- a/assertj-swing/src/test/java/org/assertj/swing/launcher/AppletLauncher_withParametersAsMap_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/launcher/AppletLauncher_withParametersAsMap_Test.java
@@ -13,8 +13,8 @@
 package org.assertj.swing.launcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Maps.newHashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.swing.test.swing.TestApplet;
@@ -34,7 +34,7 @@ public class AppletLauncher_withParametersAsMap_Test extends AppletLauncher_Test
 
   @Test
   public void should_Set_Parameters_In_Given_Map() {
-    Map<String, String> parameters = newHashMap();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("bgcolor", "blue");
     parameters.put("color", "red");
     applet = TestApplet.createNew();

--- a/assertj-swing/src/test/java/org/assertj/swing/monitor/WindowEventQueueMapping_removeMappingFor_Test.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/monitor/WindowEventQueueMapping_removeMappingFor_Test.java
@@ -13,10 +13,10 @@
 package org.assertj.swing.monitor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Maps.newHashMap;
 
 import java.awt.EventQueue;
 import java.awt.Window;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -40,7 +40,7 @@ public class WindowEventQueueMapping_removeMappingFor_Test extends WindowEventQu
   @Test
   public void should_Remove_Component_From_All_Mappings() {
     EventQueue anotherEventQueue = new EventQueue();
-    Map<Window, Boolean> windowMapping = newHashMap();
+    Map<Window, Boolean> windowMapping = new HashMap<>();
     windowMapping.put(window, true);
     queueMap.put(anotherEventQueue, windowMapping);
     mapping.removeMappingFor(window);

--- a/assertj-swing/src/test/java/org/assertj/swing/test/awt/ToolkitStub.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/test/awt/ToolkitStub.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.swing.test.awt;
 
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.mockito.Mockito.spy;
 
 import java.awt.Button;
@@ -81,6 +80,7 @@ import java.awt.peer.TextFieldPeer;
 import java.awt.peer.WindowPeer;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -99,7 +99,7 @@ public class ToolkitStub extends Toolkit {
   static ToolkitStub createNew(EventQueue eventQueue) {
     ToolkitStub stub = spy(new ToolkitStub());
     stub.eventQueue(eventQueue);
-    stub.eventListeners = newHashMap();
+    stub.eventListeners = new HashMap<>();
     return stub;
   }
 

--- a/assertj-swing/src/test/java/org/assertj/swing/test/core/MethodInvocations.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/test/core/MethodInvocations.java
@@ -14,13 +14,13 @@ package org.assertj.swing.test.core;
 
 import static java.util.Arrays.deepEquals;
 import static org.assertj.core.api.Fail.fail;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.Strings.concat;
 import static org.assertj.core.util.Strings.quote;
 import static org.assertj.swing.util.Arrays.copyOf;
 import static org.assertj.swing.util.Arrays.format;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
  * @author Yvonne Wang
  */
 public class MethodInvocations {
-  private final Map<String, Object[]> invocations = newHashMap();
+  private final Map<String, Object[]> invocations = new HashMap<>();
 
   /**
    * Records that a method with the given name was invoked.

--- a/assertj-swing/src/test/java/org/assertj/swing/test/recorder/AbstractClickRecorder.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/test/recorder/AbstractClickRecorder.java
@@ -13,13 +13,13 @@
 package org.assertj.swing.test.recorder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.swing.core.MouseButton.LEFT_BUTTON;
 import static org.assertj.swing.core.MouseButton.MIDDLE_BUTTON;
 import static org.assertj.swing.core.MouseButton.RIGHT_BUTTON;
 
 import java.awt.Point;
 import java.awt.event.MouseEvent;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -34,7 +34,7 @@ import org.assertj.swing.core.MouseButton;
  */
 public class AbstractClickRecorder {
 
-  private static final Map<Integer, MouseButton> MOUSE_BUTTON_MAP = newHashMap();
+  private static final Map<Integer, MouseButton> MOUSE_BUTTON_MAP = new HashMap<>();
 
   static {
     MOUSE_BUTTON_MAP.put(MouseEvent.BUTTON1, LEFT_BUTTON);

--- a/assertj-swing/src/test/java/org/assertj/swing/test/recorder/ToolkitClickRecorder.java
+++ b/assertj-swing/src/test/java/org/assertj/swing/test/recorder/ToolkitClickRecorder.java
@@ -13,7 +13,6 @@
 package org.assertj.swing.test.recorder;
 
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.assertj.core.util.Maps.newHashMap;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 
 import java.awt.AWTEvent;
@@ -22,6 +21,7 @@ import java.awt.Container;
 import java.awt.Toolkit;
 import java.awt.event.AWTEventListener;
 import java.awt.event.MouseEvent;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +35,7 @@ import javax.annotation.Nonnull;
  */
 public class ToolkitClickRecorder extends AbstractClickRecorder {
 
-  private static Map<ToolkitClickRecorder, ClickListener> recorderListeners = newHashMap();
+  private static Map<ToolkitClickRecorder, ClickListener> recorderListeners = new HashMap<>();
 
   ToolkitClickRecorder() {
     // hide the constructor from the outside


### PR DESCRIPTION
As assertj-swing:2.2.0 was compiled with assertj-core:2.2.0, it could not run if the latest 2.x version of assertj-core is present in the runtime environment.
I recompiled with assertj-core:2.8.0 and checked for regressions.

I'm looking forward to your feedback and will be happy to answer any questions you may have.

Sincerely