### PR TITLE
Use assertj-core 3.11.1

### DIFF
--- a/assertj-swing-junit/src/main/java/org/assertj/swing/junit/runner/FolderCreator.java
+++ b/assertj-swing-junit/src/main/java/org/assertj/swing/junit/runner/FolderCreator.java
@@ -18,8 +18,8 @@ import static org.assertj.core.util.Strings.concat;
 import static org.assertj.core.util.Strings.quote;
 
 import java.io.File;
-
-import org.assertj.core.api.exception.RuntimeIOException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 
 /**
  * Understands creation of folders.
@@ -38,7 +38,12 @@ class FolderCreator {
       imageFolder.mkdir();
       return imageFolder;
     } catch (Exception e) {
-      throw new RuntimeIOException(concat("Unable to create directory ", quote(name)), e);
+      String message = concat("Unable to create directory ", quote(name));
+
+      if (e instanceof IOException) {
+        throw new UncheckedIOException(message, (IOException) e);
+      }
+      throw new RuntimeException(message, e);
     }
   }
 }

--- a/assertj-swing-junit/src/test/java/org/assertj/swing/junit/runner/FolderCreator_createFolder_Test.java
+++ b/assertj-swing-junit/src/test/java/org/assertj/swing/junit/runner/FolderCreator_createFolder_Test.java
@@ -20,7 +20,6 @@ import static org.easymock.classextension.EasyMock.createMock;
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.api.exception.RuntimeIOException;
 import org.easymock.EasyMock;
 import org.fest.mocks.EasyMockTemplate;
 import org.junit.BeforeClass;
@@ -81,7 +80,7 @@ public class FolderCreator_createFolder_Test {
         try {
           creator.createFolder(f, "hello", true);
           fail("expecting exception");
-        } catch (RuntimeIOException e) {
+        } catch (RuntimeException e) {
           assertThat(e).hasMessage("Unable to create directory 'hello'");
           assertThat(e.getCause()).isSameAs(error);
         }

--- a/assertj-swing-testng/src/main/java/org/assertj/swing/testng/listener/OutputDirectory.java
+++ b/assertj-swing-testng/src/main/java/org/assertj/swing/testng/listener/OutputDirectory.java
@@ -16,8 +16,6 @@ import static org.assertj.core.util.Strings.concat;
 import static org.assertj.swing.util.Strings.isNullOrEmpty;
 
 import java.io.File;
-
-import org.assertj.core.api.exception.RuntimeIOException;
 import org.testng.ITestContext;
 
 /**
@@ -47,6 +45,6 @@ class OutputDirectory {
       return;
     if (f.mkdirs())
       return;
-    throw new RuntimeIOException(concat("Unable to create output directory ", path));
+    throw new RuntimeException(concat("Unable to create output directory ", path));
   }
 }

--- a/assertj-swing-testng/src/test/java/org/assertj/swing/testng/listener/OutputDirectory_createIfNecessary_Test.java
+++ b/assertj-swing-testng/src/test/java/org/assertj/swing/testng/listener/OutputDirectory_createIfNecessary_Test.java
@@ -21,8 +21,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.classextension.EasyMock.createMock;
 
 import java.io.File;
-
-import org.assertj.core.api.exception.RuntimeIOException;
 import org.fest.mocks.EasyMockTemplate;
 import org.junit.After;
 import org.junit.Before;
@@ -95,7 +93,7 @@ public class OutputDirectory_createIfNecessary_Test {
     }.run();
   }
 
-  @Test(expected = RuntimeIOException.class)
+  @Test(expected = RuntimeException.class)
   public void should_Throw_Error_If_Output_Folder_Cannot_Be_Created() {
     File folder = newFolder(unwritablePath);
     assertThat(folder.setReadOnly()).isTrue();

--- a/assertj-swing/pom.xml
+++ b/assertj-swing/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.8.0</version>
+      <version>3.11.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The assertj-swing:3.8.0 can't be run if  assertj-core:3.11.1 is present in the runtime environment. 
To resolve this issue I updated  assertj-core dependency and made some fixes.


 