### PR TITLE
Update InputState.java: Fix NPE with TrayIcon

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/input/InputState.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/input/InputState.java
@@ -109,13 +109,16 @@ public class InputState {
       }
       if (inputEvent instanceof MouseEvent) {
         MouseEvent mouseEvent = (MouseEvent) inputEvent;
-        Point eventScreenLocation = screenLocation(mouseEvent);
-        synchronized (this) {
-          lastEventTime(mouseEvent);
-          dragDropInfo.update(mouseEvent);
-          mouseInfo.modifiers(modifiers);
-          mouseInfo.update(mouseEvent, eventScreenLocation);
-          modifiers(mouseInfo.modifiers());
+        //TrayIcon might post events without a component
+        if(mouseEvent.getComponent() != null) {
+          Point eventScreenLocation = screenLocation(mouseEvent);
+          synchronized (this) {
+            lastEventTime(mouseEvent);
+            dragDropInfo.update(mouseEvent);
+            mouseInfo.modifiers(modifiers);
+            mouseInfo.update(mouseEvent, eventScreenLocation);
+            modifiers(mouseInfo.modifiers());
+          }
         }
       }
     }


### PR DESCRIPTION
Fix Issue https://github.com/joel-costigliola/assertj-swing/issues/197

I guess we can just ignore updating the screen location if we can't determine it.