### PR TITLE
Increase speed of finding components in large swing hierarchy.

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/core/FinderDelegate.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/core/FinderDelegate.java
@@ -19,7 +19,6 @@ import static org.assertj.swing.edt.GuiActionRunner.execute;
 import java.awt.Component;
 import java.util.Collection;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nonnull;
 
@@ -36,15 +35,13 @@ final class FinderDelegate {
   @RunsInEDT
   @Nonnull
   Collection<Component> find(@Nonnull ComponentHierarchy h, @Nonnull ComponentMatcher m) {
-    AtomicReference<Collection<Component>> responseReference = new AtomicReference<>();
+    Set<Component> found = newLinkedHashSet();
     execute(() -> {
-      Set<Component> found = newLinkedHashSet();
       for (Component c : rootsOf(h)) {
         find(h, m, checkNotNull(c), found);
       }
-      responseReference.set(found);
     });
-    return responseReference.get();
+    return found;
   }
 
   @RunsInEDT
@@ -74,15 +71,13 @@ final class FinderDelegate {
   @RunsInEDT
   @Nonnull
   <T extends Component> Collection<T> find(@Nonnull ComponentHierarchy h, @Nonnull GenericTypeMatcher<T> m) {
-    AtomicReference<Set<T>> responseReference = new AtomicReference<>();
+    Set<T> found = newLinkedHashSet();
     execute(() -> {
-      Set<T> found = newLinkedHashSet();
       for (Component c : rootsOf(h)) {
         find(h, m, checkNotNull(c), found);
       }
-      responseReference.set(found);
     });
-    return responseReference.get();
+    return found;
   }
 
   @RunsInEDT


### PR DESCRIPTION
We have a large swing hierarchy with many thousands of components. 

The find is VERY slow because while doing a depth first search of the hierarchy all recursive loops and match checks are queued for the swing thread and block until done.

This change causes the entire search to be done with just a single blocking invocation on the swing thread. This significantly improves the time needed to do a search on the hierarchy.


