### PR TITLE
Y and Z are swapped on QWERTZ keyboard

### DIFF
--- a/assertj-swing/src/main/java/org/assertj/swing/keystroke/KeyStrokeMappingProvider_de.java
+++ b/assertj-swing/src/main/java/org/assertj/swing/keystroke/KeyStrokeMappingProvider_de.java
@@ -180,10 +180,10 @@ public class KeyStrokeMappingProvider_de implements KeyStrokeMappingProvider {
     mappings.add(mapping('W', VK_W, SHIFT_MASK));
     mappings.add(mapping('x', VK_X, NO_MASK));
     mappings.add(mapping('X', VK_X, SHIFT_MASK));
-    mappings.add(mapping('y', VK_Y, NO_MASK));
-    mappings.add(mapping('Y', VK_Y, SHIFT_MASK));
-    mappings.add(mapping('z', VK_Z, NO_MASK));
-    mappings.add(mapping('Z', VK_Z, SHIFT_MASK));
+    mappings.add(mapping('y', VK_Z, NO_MASK));
+    mappings.add(mapping('Y', VK_Z, SHIFT_MASK));
+    mappings.add(mapping('z', VK_Y, NO_MASK));
+    mappings.add(mapping('Z', VK_Y, SHIFT_MASK));
     return mappings;
   }
 }


### PR DESCRIPTION
Hi, we faced with issue when wrong text typed when QWERTZ locale. We've tried solution from [this issue](https://github.com/assertj/assertj-swing/issues/199) but still have wrong letters - `z` and `y` are swapped. 